### PR TITLE
Vld-vst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ HEADERS = fips202x2.h fips202.h
 
 all: \
 	bench_rate_neon_fips202 \
-	bench_state_neon_fips202
+	benchmark_mem \
+	benchmark
 
 shared: \
 	libsha3x2_neon.so \
@@ -19,10 +20,14 @@ bench_rate_neon_fips202: fips202x2.c fips202.c benchmark_rate.c
 	$(CC) $(CFLAGS) $(SOURCES) benchmark_rate.c -o bench_rate_neon_fips202
 
 bench:
-	./bench_rate_neon_fips202
+	./benchmark
+	./benchmark_mem
+
+benchmark_mem: fips202x2.c fips202.c benchmark.cxx
+	c++ $(SOURCES) benchmark.cxx -DMEM=1 -o $@ -I/usr/local/include -L/usr/local/lib -lbenchmark -std=c++11  -O3
 
 benchmark: fips202x2.c fips202.c benchmark.cxx
-	c++ $(SOURCES) benchmark.cxx -o $@ -I/usr/local/include -L/usr/local/lib -lbenchmark -std=c++11  -O3
+	c++ $(SOURCES) benchmark.cxx -DMEM=0 -o $@ -I/usr/local/include -L/usr/local/lib -lbenchmark -std=c++11  -O3
 
 libsha3x2_neon.so: fips202x2.c fips202x2.h
 	$(CC) -shared -fPIC $(CFLAGS) fips202x2.c -o libsha3x2_neon.so


### PR DESCRIPTION
Add option to use VLD and VSTR instruciton. 

However the performance is not good on Apple M1. 

## SHA-3 Enable 

With SHA-3 Enable, VLD, VST Enable
```
-----------------------------------------------------
Benchmark           Time             CPU   Iterations
-----------------------------------------------------
BM_F1600x2        190 ns          190 ns      3570755
BM_F1600          219 ns          219 ns      3206567

```

With SHA-3 Enable, VLD, VST Disable
```
-----------------------------------------------------
Benchmark           Time             CPU   Iterations
-----------------------------------------------------
BM_F1600x2        155 ns          155 ns      4392570
BM_F1600          219 ns          218 ns      3216587
```

## SHA-3 Disable


With SHA-3 Disable, VLD, VST Enable
```
-----------------------------------------------------
Benchmark           Time             CPU   Iterations
-----------------------------------------------------
BM_F1600x2        359 ns          358 ns      1937014
BM_F1600          218 ns          217 ns      3214592

```

With SHA-3 Disable, VLD, VST Disable
```
-----------------------------------------------------
Benchmark           Time             CPU   Iterations
-----------------------------------------------------
BM_F1600x2        357 ns          357 ns      1952123
BM_F1600          218 ns          218 ns      3203075
```